### PR TITLE
Updated IPS Test Kit validator ENV reference

### DIFF
--- a/lib/ips_test_kit.rb
+++ b/lib/ips_test_kit.rb
@@ -9,9 +9,6 @@ module IPS
 
     validator do
       url ENV.fetch('VALIDATOR_URL', 'http://validator_service:4567')
-      exclude_message do |message|
-        VALIDATION_MESSAGE_FILTERS.any? { |filter| filter.match? message.message }
-      end
     end
     
     # Comment this out to remove

--- a/lib/ips_test_kit.rb
+++ b/lib/ips_test_kit.rb
@@ -7,6 +7,13 @@ module IPS
 
     id 'ips'
 
+    validator do
+      url ENV.fetch('VALIDATOR_URL', 'http://validator_service:4567')
+      exclude_message do |message|
+        VALIDATION_MESSAGE_FILTERS.any? { |filter| filter.match? message.message }
+      end
+    end
+    
     # Comment this out to remove
     group from: :ips_resource_validation
 


### PR DESCRIPTION
Updated the IPS Test Kit to explicitly reference the validator in the ENV file.

# Summary

# Testing Guidance

