### PR TITLE
FI-1954: add description and reference FHIR

### DIFF
--- a/lib/ips_test_kit.rb
+++ b/lib/ips_test_kit.rb
@@ -5,8 +5,8 @@ module IPS
     title 'International Patient Summary (IPS)'
     description %(
       This test suite evaluates the ability of a system to provide
-        patient summary data expressed using HL7® FHIR®
-        in accordance with the [International Patient Summary Implementation Guide (IPA IG)](https://www.hl7.org/fhir/uv/ips/).  
+      patient summary data expressed using HL7® FHIR®
+      in accordance with the [International Patient Summary Implementation Guide (IPA IG)](https://www.hl7.org/fhir/uv/ips/).  
     )
 
     id 'ips'

--- a/lib/ips_test_kit.rb
+++ b/lib/ips_test_kit.rb
@@ -6,7 +6,7 @@ module IPS
     description %(
       This test suite evaluates the ability of a system to provide
       patient summary data expressed using HL7® FHIR®
-      in accordance with the [International Patient Summary Implementation Guide (IPA IG)](https://www.hl7.org/fhir/uv/ips/).  
+      in accordance with the [International Patient Summary Implementation Guide (IPS IG)](https://www.hl7.org/fhir/uv/ips/).  
     )
 
     id 'ips'

--- a/lib/ips_test_kit.rb
+++ b/lib/ips_test_kit.rb
@@ -3,7 +3,11 @@ Dir.glob(File.join(__dir__, 'ips', '*.rb')).each { |path| require_relative path.
 module IPS
   class Suite < Inferno::TestSuite
     title 'International Patient Summary (IPS)'
-    description 'International Patient Summary (IPS)'
+    description %(
+      This test suite evaluates the ability of a system to provide
+        patient summary data expressed using HL7® FHIR®
+        in accordance with the [International Patient Summary Implementation Guide (IPA IG)](https://www.hl7.org/fhir/uv/ips/).  
+    )
 
     id 'ips'
 


### PR DESCRIPTION
# Summary

Update test suite description with reference to FHIR and trademark

# Testing Guidance

Launch test suite and validate that the description includes FHIR with a trademark symbol