### PR TITLE
Change $summary operation to GET due to unusual POST behavior.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ips_test_kit (0.1.1)
-      inferno_core (>= 0.4.2)
+      inferno_core (>= 0.4.21)
 
 GEM
   remote: https://rubygems.org/

--- a/config/presets/IPS_reference_server_preset.json
+++ b/config/presets/IPS_reference_server_preset.json
@@ -5,7 +5,7 @@
     "inputs": [
         {
             "name": "url",
-            "value": "https://hl7-ips-server.hl7.org/fhir/",
+            "value": "https://hl7-ips-server.hl7.org/fhir",
             "_type": "text"
         },
         {

--- a/ips_test_kit.gemspec
+++ b/ips_test_kit.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'IPS Tests'
   spec.homepage      = 'https://github.com/inferno-framework/ips-test-kit'
   spec.license       = 'Apache-2.0'
-  spec.add_runtime_dependency 'inferno_core', '>= 0.4.2'
+  spec.add_runtime_dependency 'inferno_core', '>= 0.4.21'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'
   spec.add_development_dependency 'rspec', '~> 3.10'

--- a/lib/ips/summary_operation.rb
+++ b/lib/ips/summary_operation.rb
@@ -36,7 +36,7 @@ module IPS
     test do
       title 'IPS Server returns Bundle resource for Patient/[id]/$summary GET operation'
       description %(
-        IPS Server return valid IPS Bundle resource as successful result of
+        IPS Server returns a valid IPS Bundle resource as successful result of
         $summary operation.
 
         This test currently only issues a GET request for the summary due to a
@@ -47,8 +47,8 @@ module IPS
 
         A future update to this test suite should include a required POST
         request as well as an optional GET request for this content.
-
       )
+
       input :patient_id
       makes_request :summary_operation
 

--- a/lib/ips/summary_operation.rb
+++ b/lib/ips/summary_operation.rb
@@ -34,20 +34,26 @@ module IPS
     end
 
     test do
-      title 'IPS Server returns Bundle resource for Patient/id/$summary operation'
+      title 'IPS Server returns Bundle resource for Patient/[id]/$summary GET operation'
       description %(
-        IPS Server return valid IPS Bundle resource as successful result of $summary operation.
+        IPS Server return valid IPS Bundle resource as successful result of
+        $summary operation.
 
-        This is required to be a POST per the [guidance](http://hl7.org/fhir/uv/ips/STU1.1/ipsGeneration.html):
+        This test currently only issues a GET request for the summary due to a
+        limitation in Inferno in issuing POST requests that omit a Content-Type
+        header when the body is empty. Inferno currently adds a `Content-Type:
+        application/x-www-form-urlencoded` header when issuing a POST with no
+        body, which causes issues in known reference implementations.
 
-        >  This operation returns an IPS document Bundle in response to a POST request.
+        A future update to this test suite should include a required POST
+        request as well as an optional GET request for this content.
 
       )
       input :patient_id
       makes_request :summary_operation
 
       run do
-        fhir_operation("Patient/#{patient_id}/$summary", name: :summary_operation, operation_method: :post)
+        fhir_operation("Patient/#{patient_id}/$summary", name: :summary_operation, operation_method: :get)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_resource(profile_url: 'http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips')


### PR DESCRIPTION
# Summary
When issuing a $summary operation on POST, the Ruby gems used by Inferno silently adds a Content-Type header even though there is no body.  Known implementations have trouble with this, as it is unexpected to state that an empty body has a Content-Type, and that Content-Type isn't a normal FHIR Content-Type.

GET is allowed for this operation, as it doesn't affect state.  This changes the operation to use a GET for the time being to avoid having tests with questionable behavior.

The Inferno team is looking at how to override this unusual behavior by the HTTP gem being used to issue the requests.

# Testing Guidance
Before, the HAPI reference server preset returned a 400 on the summary request.  Afterwards, HAPI returns content (that doesn't pass validation, which is a separate issue).

<img width="1481" alt="Screenshot 2024-03-04 at 12 22 34 PM" src="https://github.com/inferno-framework/ips-test-kit/assets/412901/d1b2f9e1-15fd-4ef5-bac0-bb78557b399a">



