### PR TITLE
FI-2544 Release v0.9.0 IPS Test Kit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ips_test_kit (0.1.1)
+    ips_test_kit (0.9.0)
       inferno_core (>= 0.4.21)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -13,49 +13,17 @@ a preliminary test suite.
 
 ## Instructions
 
+It is highly recommended that you use [Docker](https://www.docker.com/) to run
+these tests.  This test kit requires at least 10 GB of memory are available to Docker.
+
 - Clone this repo.
-- Write your tests in the `lib` folder.
-- Put the `package.tgz` for the IG you're writing tests for in
-  `lib/your_test_kit_name/igs` and update this path in `docker-compose.yml`.
-  This will ensure that the validator has access to the resources needed to
-  validate resources against your IG.
-- Run `setup.sh` in this repo to pull the needed docker images and set up the
-  database.
-- Run `run.sh` to build your tests and run inferno.
-- Navigate to `http://localhost` to access Inferno, where your test suite will
-  be available. To access the FHIR resource validator, navigate to
-  `http://localhost/validator`.
+- Run `setup.sh` in this repo.
+- Run `run.sh` in this repo.
+- Navigate to `http://localhost`. The IPS Test suite will be available.
 
-## Distributing tests
-
-In order to make your test suite available to others, it needs to be organized
-like a standard ruby gem (ruby libraries are called gems).
-
-- Fill in the information in the `gemspec` file in the root of this repository.
-  The name of this file should match the `spec.name` within the file. This will
-  be the name of the gem you create. For example, if your file is
-  `my_test_kit.gemspec` and its `spec.name` is `'my_test_kit'`, then others will
-  be able to install your gem with `gem install my_test_kit`. There are
-  [recommended naming conventions for
-  gems](https://guides.rubygems.org/name-your-gem/).
-- Your tests must be in `lib`
-- `lib` should contain only one file. All other files should be in a
-  subdirectory. The file in lib be what people use to import your gem after they
-  have installed it. For example, if your test kit contains a file
-  `lib/my_test_suite.rb`, then after installing your test kit gem, I could
-  include your test suite with `require 'my_test_suite'`.
-- **Optional:** Once your gemspec file has been updated, you can publish your
-  gem on [rubygems, the official ruby gem repository](https://rubygems.org/). If
-  you don't publish your gem on rubygems, users will still be able to install it
-  if it is located in a public git repository. To publish your gem on rubygems,
-  you will first need to [make an account on
-  rubygems](https://guides.rubygems.org/publishing/#publishing-to-rubygemsorg)
-  and then run `gem build *.gemspec` and `gem push *.gem`.
-
-## Example Inferno test kits
-
-- https://github.com/inferno-community/ips-test-kit
-- https://github.com/inferno-community/shc-vaccination-test-kit
+See the [Inferno Framework
+Documentation](https://inferno-framework.github.io/docs/getting-started-users.html)
+for more information on running Inferno.
 
 ## License
 

--- a/lib/ips/version.rb
+++ b/lib/ips/version.rb
@@ -1,3 +1,3 @@
 module IPS
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.9.0'.freeze
 end


### PR DESCRIPTION
# Release Summary:

* Updates HL7 IPS Reference Server preset to point to new domain
* Adds separate preset for content-only tests, and fixes issues where preset was rendering as Ruby object instead of JSON in the input field for the test
* Adds descriptions to suite and tests to describe the testing capability of this set of tests and how to use the presets
* Removes $document operation test as it had a critical bug in the Inferno test, but is not documented in the current version of the IPS IG and there are no known reference implementations so fixing it was not possible
* Updates $summary test to use GET as the POST version for FHIR Operations in Inferno forces a Content-Type header when it is not appropriate, which causes issues in some reference implementations
* Updates inferno_core dependency to ensure that GET for FHIR Operations is provided 
* Adds very basic $docref test that verifies support for this operation and initiates a request, but does very little to validate the response due to lack of available references
* Updates to v0.9.0 to match convention of other test kits that are ready to be deployed to inferno.healthit.gov

