### PR TITLE
Release v0.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ips_test_kit (0.9.0)
+    ips_test_kit (0.9.1)
       inferno_core (>= 0.4.37)
 
 GEM

--- a/lib/ips/version.rb
+++ b/lib/ips/version.rb
@@ -1,3 +1,3 @@
 module IPS
-  VERSION = '0.9.0'.freeze
+  VERSION = '0.9.1'.freeze
 end


### PR DESCRIPTION
# Summary

* Dependency Updates 2024-03-19 by @Jammjammjamm in https://github.com/inferno-framework/ips-test-kit/pull/36
* Dependency Updates 2024-04-05 by @Jammjammjamm in https://github.com/inferno-framework/ips-test-kit/pull/37
* FI-2429: Migrate to HL7 validator wrapper by @dehall in https://github.com/inferno-framework/ips-test-kit/pull/38
* Dependency Updates 2024-06-05 by @Jammjammjamm in https://github.com/inferno-framework/ips-test-kit/pull/39

