### PR TITLE
Separation of IPS $summary Tests with Configurable Variables for Reusability

### DIFF
--- a/lib/ips/summary_operation.rb
+++ b/lib/ips/summary_operation.rb
@@ -1,5 +1,6 @@
 require_relative './summary_operation_return_bundle'
 require_relative './summary_operation_support_operation'
+require_relative './summary_operation_valid_composition'
 module IPS
   class SummaryOperation < Inferno::TestGroup
     title 'Summary Operation Tests'
@@ -24,25 +25,12 @@ module IPS
            }
          }
 
-    test do
-      title 'IPS Server returns Bundle resource containing valid IPS Composition entry'
-      description %(
-        IPS Server return valid IPS Composition resource in the Bundle as first entry
-      )
-      # link 'http://hl7.org/fhir/uv/ips/StructureDefinition-Composition-uv-ips.html'
-      uses_request :summary_operation
-
-      run do
-        skip_if !resource.is_a?(FHIR::Bundle), 'No Bundle returned from document operation'
-
-        assert resource.entry.length.positive?, 'Bundle has no entries'
-
-        first_resource = resource.entry.first.resource
-
-        assert first_resource.is_a?(FHIR::Composition), 'The first entry in the Bundle is not a Composition'
-        assert_valid_resource(resource: first_resource, profile_url: 'http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips')
-      end
-    end
+    test from: :ips_summary_operation_valid_composition,
+         config: {
+           options: {
+             profile_url: 'http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips'
+           }
+         }
 
     test do
       title 'IPS Server returns Bundle resource containing valid IPS MedicationStatement entry'

--- a/lib/ips/summary_operation.rb
+++ b/lib/ips/summary_operation.rb
@@ -1,5 +1,5 @@
 require_relative './summary_operation_return_bundle'
-require_relative './summary_operation_support_operation'
+require_relative './summary_operation_support'
 require_relative './summary_operation_valid_composition'
 module IPS
   class SummaryOperation < Inferno::TestGroup
@@ -11,26 +11,11 @@ module IPS
     id :ips_summary_operation
     run_as_group
 
-    test from: :ips_summary_operation_support_operation,
-         config: {
-           options: {
-             ips_summary_operation_definition_url: 'http://hl7.org/fhir/uv/ips/OperationDefinition/summary'
-           }
-         }
+    test from: :ips_summary_operation_support
 
-    test from: :ips_summary_operation_return_bundle,
-         config: {
-           options: {
-             profile_url: 'http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips'
-           }
-         }
+    test from: :ips_summary_operation_return_bundle
 
-    test from: :ips_summary_operation_valid_composition,
-         config: {
-           options: {
-             profile_url: 'http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips'
-           }
-         }
+    test from: :ips_summary_operation_valid_composition
 
     test do
       title 'IPS Server returns Bundle resource containing valid IPS MedicationStatement entry'

--- a/lib/ips/summary_operation.rb
+++ b/lib/ips/summary_operation.rb
@@ -1,3 +1,5 @@
+require_relative './summary_operation_return_bundle'
+require_relative './summary_operation_support_operation'
 module IPS
   class SummaryOperation < Inferno::TestGroup
     title 'Summary Operation Tests'
@@ -8,57 +10,9 @@ module IPS
     id :ips_summary_operation
     run_as_group
 
-    test do
-      title 'IPS Server declares support for $summary operation in CapabilityStatement'
-      description %(
-        The IPS Server declares support for Patient/[id]/$summary operation in its server CapabilityStatement
-      )
+    test from: :ips_summary_operation_support_operation
 
-      run do
-        fhir_get_capability_statement
-        assert_response_status(200)
-
-        operations = resource.rest&.flat_map do |rest|
-          rest.resource
-            &.select { |r| r.type == 'Patient' && r.respond_to?(:operation) }
-            &.flat_map(&:operation)
-        end&.compact
-
-        operation_defined = operations.any? do |operation|
-          operation.definition == 'http://hl7.org/fhir/uv/ips/OperationDefinition/summary' ||
-            ['summary', 'patient-summary'].include?(operation.name.downcase)
-        end
-
-        assert operation_defined, 'Server CapabilityStatement did not declare support for $summary operation in Patient resource.'
-      end
-    end
-
-    test do
-      title 'IPS Server returns Bundle resource for Patient/[id]/$summary GET operation'
-      description %(
-        IPS Server returns a valid IPS Bundle resource as successful result of
-        $summary operation.
-
-        This test currently only issues a GET request for the summary due to a
-        limitation in Inferno in issuing POST requests that omit a Content-Type
-        header when the body is empty. Inferno currently adds a `Content-Type:
-        application/x-www-form-urlencoded` header when issuing a POST with no
-        body, which causes issues in known reference implementations.
-
-        A future update to this test suite should include a required POST
-        request as well as an optional GET request for this content.
-      )
-
-      input :patient_id
-      makes_request :summary_operation
-
-      run do
-        fhir_operation("Patient/#{patient_id}/$summary", name: :summary_operation, operation_method: :get)
-        assert_response_status(200)
-        assert_resource_type(:bundle)
-        assert_valid_resource(profile_url: 'http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips')
-      end
-    end
+    test from: :ips_summary_operation_return_bundle
 
     test do
       title 'IPS Server returns Bundle resource containing valid IPS Composition entry'

--- a/lib/ips/summary_operation.rb
+++ b/lib/ips/summary_operation.rb
@@ -10,9 +10,19 @@ module IPS
     id :ips_summary_operation
     run_as_group
 
-    test from: :ips_summary_operation_support_operation
+    test from: :ips_summary_operation_support_operation,
+         config: {
+           options: {
+             ips_summary_operation_definition_url: 'http://hl7.org/fhir/uv/ips/OperationDefinition/summary'
+           }
+         }
 
-    test from: :ips_summary_operation_return_bundle
+    test from: :ips_summary_operation_return_bundle,
+         config: {
+           options: {
+             profile_url: 'http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips'
+           }
+         }
 
     test do
       title 'IPS Server returns Bundle resource containing valid IPS Composition entry'

--- a/lib/ips/summary_operation_return_bundle.rb
+++ b/lib/ips/summary_operation_return_bundle.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module IPS
-  class SummaryOperationReturnBundle< Inferno::Test
+  class SummaryOperationReturnBundle < Inferno::Test
     title 'IPS Server returns Bundle resource for Patient/[id]/$summary GET operation'
     description %(
       IPS Server returns a valid IPS Bundle resource as successful result of
@@ -19,11 +21,17 @@ module IPS
     input :patient_id
     makes_request :summary_operation
 
+    class << self
+      def profile_url
+        @profile_url ||= config.options[:profile_url]
+      end
+    end
+
     run do
       fhir_operation("Patient/#{patient_id}/$summary", name: :summary_operation, operation_method: :get)
       assert_response_status(200)
       assert_resource_type(:bundle)
-      assert_valid_resource(profile_url: 'http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips')
+      assert_valid_resource(profile_url: self.class.profile_url)
     end
   end
 end

--- a/lib/ips/summary_operation_return_bundle.rb
+++ b/lib/ips/summary_operation_return_bundle.rb
@@ -23,7 +23,7 @@ module IPS
 
     class << self
       def profile_url
-        @profile_url ||= config.options[:profile_url]
+        @profile_url ||= config.options[:ips_bundle_profile_url] || 'http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips'
       end
     end
 

--- a/lib/ips/summary_operation_return_bundle.rb
+++ b/lib/ips/summary_operation_return_bundle.rb
@@ -1,0 +1,29 @@
+module IPS
+  class SummaryOperationReturnBundle< Inferno::Test
+    title 'IPS Server returns Bundle resource for Patient/[id]/$summary GET operation'
+    description %(
+      IPS Server returns a valid IPS Bundle resource as successful result of
+      $summary operation.
+
+      This test currently only issues a GET request for the summary due to a
+      limitation in Inferno in issuing POST requests that omit a Content-Type
+      header when the body is empty. Inferno currently adds a `Content-Type:
+      application/x-www-form-urlencoded` header when issuing a POST with no
+      body, which causes issues in known reference implementations.
+
+      A future update to this test suite should include a required POST
+      request as well as an optional GET request for this content.
+    )
+    id :ips_summary_operation_return_bundle
+
+    input :patient_id
+    makes_request :summary_operation
+
+    run do
+      fhir_operation("Patient/#{patient_id}/$summary", name: :summary_operation, operation_method: :get)
+      assert_response_status(200)
+      assert_resource_type(:bundle)
+      assert_valid_resource(profile_url: 'http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips')
+    end
+  end
+end

--- a/lib/ips/summary_operation_support.rb
+++ b/lib/ips/summary_operation_support.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 module IPS
-  class SummaryOperationSupportOperation < Inferno::Test
+  class SummaryOperationSupport < Inferno::Test
     title 'IPS Server declares support for $summary operation in CapabilityStatement'
     description %(
       The IPS Server declares support for Patient/[id]/$summary operation in its server CapabilityStatement
     )
-    id :ips_summary_operation_support_operation
+    id :ips_summary_operation_support
 
     class << self
       def ips_summary_operation_definition_url
-        @ips_summary_operation_definition_url ||= config.options[:ips_summary_operation_definition_url]
+        @ips_summary_operation_definition_url ||= config.options[:ips_summary_operation_definition_url] || 'http://hl7.org/fhir/uv/ips/OperationDefinition/summary'
       end
     end
 

--- a/lib/ips/summary_operation_support_operation.rb
+++ b/lib/ips/summary_operation_support_operation.rb
@@ -8,6 +8,12 @@ module IPS
     )
     id :ips_summary_operation_support_operation
 
+    class << self
+      def ips_summary_operation_definition_url
+        @ips_summary_operation_definition_url ||= config.options[:ips_summary_operation_definition_url]
+      end
+    end
+
     run do
       fhir_get_capability_statement
       assert_response_status(200)
@@ -19,7 +25,7 @@ module IPS
       end&.compact
 
       operation_defined = operations.any? do |operation|
-        operation.definition == 'http://hl7.org/fhir/uv/ips/OperationDefinition/summary' ||
+        operation.definition == self.class.ips_summary_operation_definition_url ||
           %w[summary patient-summary].include?(operation.name.downcase)
       end
 

--- a/lib/ips/summary_operation_support_operation.rb
+++ b/lib/ips/summary_operation_support_operation.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module IPS
+  class SummaryOperationSupportOperation < Inferno::Test
+    title 'IPS Server declares support for $summary operation in CapabilityStatement'
+    description %(
+      The IPS Server declares support for Patient/[id]/$summary operation in its server CapabilityStatement
+    )
+    id :ips_summary_operation_support_operation
+
+    run do
+      fhir_get_capability_statement
+      assert_response_status(200)
+
+      operations = resource.rest&.flat_map do |rest|
+        rest.resource
+            &.select { |r| r.type == 'Patient' && r.respond_to?(:operation) }
+            &.flat_map(&:operation)
+      end&.compact
+
+      operation_defined = operations.any? do |operation|
+        operation.definition == 'http://hl7.org/fhir/uv/ips/OperationDefinition/summary' ||
+          %w[summary patient-summary].include?(operation.name.downcase)
+      end
+
+      assert operation_defined,
+             'Server CapabilityStatement did not declare support for $summary operation in Patient resource.'
+    end
+  end
+end

--- a/lib/ips/summary_operation_valid_composition.rb
+++ b/lib/ips/summary_operation_valid_composition.rb
@@ -9,7 +9,7 @@ module IPS
 
     class << self
       def profile_url
-        @profile_url ||= config.options[:profile_url]
+        @profile_url ||= config.options[:ips_composition_profile_url] || 'http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips'
       end
     end
 

--- a/lib/ips/summary_operation_valid_composition.rb
+++ b/lib/ips/summary_operation_valid_composition.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module IPS
+  class SummaryOperationValidComposition < Inferno::Test
+    title 'IPS Server returns Bundle resource containing valid IPS Composition entry'
+    description 'IPS Server return valid IPS Composition resource in the Bundle as first entry'
+    id :ips_summary_operation_valid_composition
+    uses_request :summary_operation
+
+    class << self
+      def profile_url
+        @profile_url ||= config.options[:profile_url]
+      end
+    end
+
+    run do
+      skip_if !resource.is_a?(FHIR::Bundle), 'No Bundle returned from document operation'
+      assert resource.entry.length.positive?, 'Bundle has no entries'
+
+      first_resource = resource.entry.first.resource
+
+      assert first_resource.is_a?(FHIR::Composition), 'The first entry in the Bundle is not a Composition'
+      assert_valid_resource(resource: first_resource, profile_url: self.class.profile_url)
+    end
+  end
+end


### PR DESCRIPTION
# Issue
https://github.com/inferno-framework/ips-test-kit/issues/45

# Summary
Tw tests were moved to separate files
1. **IPS Server declares support for the $summary operation in the CapabilityStatement**. The ability to configure _ips_summary_operation_definition_url_ variable was added;
2. **'IPS Server returns a Bundle resource for the Patient/[id]/$summary GET operation'** and **IPS Server returns Bundle resource containing valid IPS Composition entry**. The ability to configure the _profile_url_ variable was added.

# Motivation
We want to reuse these tests in our suite with different variables, while also keeping this repository as the source of truth for the IPS test suite.

# Testing Guidance
Manually testing
